### PR TITLE
Update PDO lastInsertedId return type to allow int

### DIFF
--- a/src/PDO.php
+++ b/src/PDO.php
@@ -101,7 +101,7 @@ class PDO extends \PDO
         throw new \Exception('Not implemented');
     }
 
-    public function lastInsertId(?string $name = null): string|false
+    public function lastInsertId(?string $name = null): string|int|false
     {
         return $this->conn->lastInsertId();
     }


### PR DESCRIPTION
Right now we getting this exception for inserting something:
 TypeError 
  Libsql\PDO::lastInsertId(): Return value must be of type string|false, int returned
  
  Thats because the return type is string|false and should be also int.